### PR TITLE
Avoid erroneous unsupported descriptor warning

### DIFF
--- a/utils/collectdutil/config.py
+++ b/utils/collectdutil/config.py
@@ -131,6 +131,7 @@ class Config(object):
                                          .format(str(child.values)))
                         continue
                     self.extra_dimensions[child.values[0]] = child.values[1]
+                    continue
                 if descriptor not in self.descriptors:
                     collectd.warning('Unsupported config descriptor "{0.key}".'.format(child))
                     continue

--- a/utils/setup.py
+++ b/utils/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='collectdutil',
-    version='0.0.1',
+    version='0.0.2',
     description='Utilities for development of collectd plugins',
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Prevents unnecessary evaluation of sourced descriptor before incorrect warning is emitted.  Bumping version as well.